### PR TITLE
Check for case when zipRoot and file are the same

### DIFF
--- a/Tasks/Zip/zip.ts
+++ b/Tasks/Zip/zip.ts
@@ -32,7 +32,10 @@ try {
         console.log(file);
         var stat = fs.statSync(file);
         if (stat.isDirectory()) {
-            zipFile.addEmptyDirectory(path.relative(zipRoot, file));
+             var result = path.relative(zipRoot, file);
+	         if( result ) {
+	          zipFile.addEmptyDirectory(result);
+	         }
         } else {
             zipFile.addFile(file, path.relative(zipRoot, file));
         }


### PR DESCRIPTION
I ran into an issue today with this extension when I set the following parameters:

Copy Root: $(Build.SourcesDirectory)\na (matches my repo mapping)
Contents: !/$*{,/**}

Log results:

2017-02-10T15:51:59.3966659Z ##[debug]find C:\TfsData\Build\_work\70\s
2017-02-10T15:51:59.3966659Z ##[debug]14368 matches.
 2017-02-10T15:51:59.5685320Z zipping following files :
 2017-02-10T15:51:59.5685320Z C:\TfsData\Build\_work\70\s
 2017-02-10T15:51:59.5685320Z ##[debug]task result: Failed
 2017-02-10T15:51:59.5841571Z ##[error]Error: empty metadataPath

After troubleshooting, I determined that I was running into a case where zipRoot and file where equal. In this case, path.relative returns an empty string which causes the addEmtpyDirectory method to fail. 

I resolved the issue by created a check for this. 